### PR TITLE
Delsys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ Makefile.in
 # other
 *.pyc
 
+# output files
+*.xspf
+

--- a/src/countries.c
+++ b/src/countries.c
@@ -612,6 +612,7 @@ int dvbt_transmission_mode(int channel, int channellist)
 int delsysloop_min(int channel, int channellist)
 {
 	switch (channellist) {
+	case DVBT_DE:
 	case DVBT2_CO:
 		return 1;	//DVB-T2 only.
 	default:


### PR DESCRIPTION
DVB-T is no longer in use in DE and AT, so avoid the unnecessary scan loop. I don't know if this is correct for the other countries in the DVBT_DE list.