### PR TITLE
Rework after discussion about the use of delivery systems in countries / regions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,6 @@ Makefile.in
 
 # output files
 *.xspf
+*.conf
+*.m3u
 

--- a/src/countries.c
+++ b/src/countries.c
@@ -611,11 +611,19 @@ int dvbt_transmission_mode(int channel, int channellist)
  */
 int delsysloop_min(int channel, int channellist, uint16_t delsys)
 {
-	info("desysloop_min: %s\n", delivery_system_name(delsys));	
-	switch (channellist) {
-	case DVBT2_CO:
-		return 1;	//DVB-T2 only.
-	default:
+	switch (delsys) {
+	case SYS_UNDEFINED:
+		switch (channellist) {
+		case DVBT2_CO:
+			return 1;	//DVB-T2 only.
+		default:
+			return 0;
+		}
+	case SYS_DVBT:
+		return 0;
+	case SYS_DVBT2:
+		return 1;
+	default:	// not possible
 		return 0;
 	}
 }
@@ -625,20 +633,28 @@ int delsysloop_min(int channel, int channellist, uint16_t delsys)
  */
 int delsysloop_max(int channel, int channellist, uint16_t delsys)
 {
-	info("desysloop_max: %s\n", delivery_system_name(delsys));	
-	switch (channellist) {
-	case ATSC_VSB:
-	case ATSC_QAM:
-	case DVBC_QAM:
-	case DVBC_FI:
-	case DVBC_FR:
-	case DVBC_BR:
-	case ISDBT_6MHZ:
-	case DAB_DE:
-	case USERLIST:
+	switch (delsys) {
+	case SYS_UNDEFINED:
+		switch (channellist) {
+		case ATSC_VSB:
+		case ATSC_QAM:
+		case DVBC_QAM:
+		case DVBC_FI:
+		case DVBC_FR:
+		case DVBC_BR:
+		case ISDBT_6MHZ:
+		case DAB_DE:
+		case USERLIST:
+			return 0;
+		default:
+			return 1;
+		}
+	case SYS_DVBT:
 		return 0;
-	default:
+	case SYS_DVBT2:
 		return 1;
+	default:	// not possible
+		return 0;
 	}
 }
 

--- a/src/countries.c
+++ b/src/countries.c
@@ -609,8 +609,9 @@ int dvbt_transmission_mode(int channel, int channellist)
 /*
  * some countries don't use legacy delsys anymore
  */
-int delsysloop_min(int channel, int channellist)
+int delsysloop_min(int channel, int channellist, uint16_t delsys)
 {
+	info("desysloop_min: %s\n", delivery_system_name(delsys));	
 	switch (channellist) {
 	case DVBT2_CO:
 		return 1;	//DVB-T2 only.
@@ -622,8 +623,9 @@ int delsysloop_min(int channel, int channellist)
 /*
  * some countries don't use 2nd gen delsys yet
  */
-int delsysloop_max(int channel, int channellist)
+int delsysloop_max(int channel, int channellist, uint16_t delsys)
 {
+	info("desysloop_max: %s\n", delivery_system_name(delsys));	
 	switch (channellist) {
 	case ATSC_VSB:
 	case ATSC_QAM:

--- a/src/countries.c
+++ b/src/countries.c
@@ -612,7 +612,6 @@ int dvbt_transmission_mode(int channel, int channellist)
 int delsysloop_min(int channel, int channellist)
 {
 	switch (channellist) {
-	case DVBT_DE:
 	case DVBT2_CO:
 		return 1;	//DVB-T2 only.
 	default:

--- a/src/countries.c
+++ b/src/countries.c
@@ -609,28 +609,35 @@ int dvbt_transmission_mode(int channel, int channellist)
 /*
  * some countries don't use legacy delsys anymore
  */
-int delsysloop_min (int country_id)
+int delsysloop_min(int channel, int channellist)
 {
-	switch (country_id) {
-	case AT:		//      AUSTRIA
-	case DE:		//      GERMANY
-	case CO:		//      COLOMBIA
-		return 1;	//DVB-T2
+	switch (channellist) {
+	case DVBT_DE:
+	case DVBT2_CO:
+		return 1;	//DVB-T2 only.
 	default:
-		return 0;	//DVB-T
+		return 0;
 	}
 }
 
 /*
  * some countries don't use 2nd gen delsys yet
  */
-int delsysloop_max(int country_id)
+int delsysloop_max(int channel, int channellist)
 {
-	switch (country_id) {
-	case -1:		//      countries to be added here
-		return 0;	//DVB-T
+	switch (channellist) {
+	case ATSC_VSB:
+	case ATSC_QAM:
+	case DVBC_QAM:
+	case DVBC_FI:
+	case DVBC_FR:
+	case DVBC_BR:
+	case ISDBT_6MHZ:
+	case DAB_DE:
+	case USERLIST:
+		return 0;
 	default:
-		return 1;	//DVB-T2
+		return 1;
 	}
 }
 

--- a/src/countries.h
+++ b/src/countries.h
@@ -86,8 +86,8 @@ int freq_offset(int channel, int channellist, int index);
 int max_dvbc_srate(int bandwidth);
 
 int dvbt_transmission_mode(int channel, int channellist);
-int delsysloop_min(int channel, int channellist);
-int delsysloop_max(int channel, int channellist);
+int delsysloop_min(int channel, int channellist, uint16_t delsys);
+int delsysloop_max(int channel, int channellist, uint16_t delsys);
 
 int dvbc_qam_max(int channel, int channellist);
 int dvbc_qam_min(int channel, int channellist);

--- a/src/countries.h
+++ b/src/countries.h
@@ -88,8 +88,8 @@ int plp_id_loop_min (int country_id);
 int plp_id_loop_max (int country_id);
 
 int dvbt_transmission_mode(int channel, int channellist);
-int delsysloop_min(int country_id);
-int delsysloop_max(int country_id);
+int delsysloop_min(int channel, int channellist);
+int delsysloop_max(int channel, int channellist);
 
 int dvbc_qam_max(int channel, int channellist);
 int dvbc_qam_min(int channel, int channellist);

--- a/src/scan.c
+++ b/src/scan.c
@@ -4864,8 +4864,13 @@ int main(int argc, char **argv)
 			sleep(10);	// enshure that user reads warning.
 		}
 	}
-	info("scan type %s, delivery system %s, channellist %d\n",
-	     scantype_to_text(scantype), delivery_system_name(flags.delsys), this_channellist);
+	if (scantype == SCAN_TERRESTRIAL) {
+		info("scan type %s, delivery system %s, channellist %d\n",
+			scantype_to_text(scantype), delivery_system_name(flags.delsys), this_channellist);
+	} else {
+		info("scan type %s, channellist %d\n",
+			scantype_to_text(scantype), this_channellist);
+	}
 	switch (output_format) {
 	case OUTPUT_VDR:
 		switch (flags.vdr_version) {

--- a/src/scan.c
+++ b/src/scan.c
@@ -106,6 +106,7 @@ struct w_scan_flags flags = {
 	0,			// print pmt
 	0,			// emulate
 	0,			// delete duplicate transponders
+	SYS_UNDEFINED, // delivery system not defined
 };
 
 static unsigned int delsys_min = 0;	// initialization of delsys loop. 0 = delsys legacy.
@@ -4374,7 +4375,6 @@ int main(int argc, char **argv)
 	int frontend_fd = -1;
 	int fe_open_mode;
 	uint16_t scantype = SCAN_TERRESTRIAL;
-	uint16_t delsys = SYS_UNDEFINED;
 	int Radio_Services = 1;
 	int TV_Services = 1;
 	int Other_Services = 0;	// 20080106: don't search other services by default.
@@ -4455,11 +4455,11 @@ int main(int argc, char **argv)
 				scantype = SCAN_TERRESTRIAL;
 			if (strcmp(optarg, "t1") == 0) {
 				scantype = SCAN_TERRESTRIAL;
-				delsys = SYS_DVBT;
+				flags.delsys = SYS_DVBT;
 			}
 			if (strcmp(optarg, "t2") == 0) {
 				scantype = SCAN_TERRESTRIAL;
-				delsys = SYS_DVBT2;
+				flags.delsys = SYS_DVBT2;
 			}
 			if (strcmp(optarg, "c") == 0)
 				scantype = SCAN_CABLE;
@@ -4865,7 +4865,7 @@ int main(int argc, char **argv)
 		}
 	}
 	info("scan type %s, delivery system %s, channellist %d\n",
-	     scantype_to_text(scantype), delivery_system_name(delsys), this_channellist);
+	     scantype_to_text(scantype), delivery_system_name(flags.delsys), this_channellist);
 	switch (output_format) {
 	case OUTPUT_VDR:
 		switch (flags.vdr_version) {

--- a/src/scan.c
+++ b/src/scan.c
@@ -114,8 +114,8 @@ static unsigned int modulation_min = 0;	// initialization of modulation loop. QA
 static unsigned int modulation_max = 1;	// initialization of modulation loop. QAM256 if FE_QAM
 static unsigned int dvbc_symbolrate_min = 0;	// initialization of symbolrate loop. 6900
 static unsigned int dvbc_symbolrate_max = 1;	// initialization of symbolrate loop. 6875
-static unsigned int plp_id_min = 0; // initialization of delsys loop.
-static unsigned int plp_id_max = 0; // initialization of delsys loop.
+static unsigned int plp_id_min = 0; // initialization of plp_id loop.
+static unsigned int plp_id_max = 0; // initialization of plp_id loop.
 static unsigned int freq_offset_min = 0;	// initialization of freq offset loop. 0 == offset (0), 1 == offset(+), 2 == offset(-), 3 == offset1(+), 4 == offset2(+)
 static unsigned int freq_offset_max = 4;	// initialization of freq offset loop.
 static int this_channellist = DVBT_DE;	// w_scan2 uses by default DVB-t

--- a/src/scan.c
+++ b/src/scan.c
@@ -3208,7 +3208,11 @@ static int initial_tune(int frontend_fd, int tuning_data)
 											info("%d: skipped (already known transponder)\n", freq_scale(f, 1e-3));
 											continue;
 										}
-										info("%d: plp%d ", freq_scale(f, 1e-3), test.plp_id);
+										if (delsys == SYS_DVBT) {
+											info("%d: ", freq_scale(f, 1e-3));
+										} else {
+											info("%d: plp%d ", freq_scale(f, 1e-3), test.plp_id);
+										}
 									} else {
 										if (is_known_initial_transponder(&test, 0))
 											continue;

--- a/src/scan.c
+++ b/src/scan.c
@@ -3123,9 +3123,9 @@ static int initial_tune(int frontend_fd, int tuning_data)
 			modulation_min = modulation_max = 0;
 			dvbc_symbolrate_min = dvbc_symbolrate_max = 0;
 			// enable legacy delsys loop.
-			delsys_min = delsysloop_min(0, this_channellist);
+			delsys_min = delsysloop_min(0, this_channellist, flags.delsys);
 			// enable T2 loop.
-			delsys_max = delsysloop_max(0, this_channellist);
+			delsys_max = delsysloop_max(0, this_channellist, flags.delsys);
 			break;
 		case SCAN_CABLE:
 			// if choosen srate is too high for channellist's bandwidth,

--- a/src/scan.c
+++ b/src/scan.c
@@ -4129,10 +4129,12 @@ static const char *usage = "\n"
     "usage: %s [options...] \n"
     "       -f type, --frontend type\n"
     "               What programs do you want to search for?\n"
-    "               a = atsc (vsb/qam)\n"
-    "               c = cable \n"
-    "               s = sat \n"
-    "               t = terrestrian [default]\n"
+    "               a  = atsc (vsb/qam)\n"
+    "               c  = cable \n"
+    "               s  = sat \n"
+    "               t  = terrestrian DVB-T and DVB-T2 [default]\n"
+    "               t1 = terrestrian DVB-T only\n"
+    "               t2 = terrestrian DVB-T2 only\n"
     "       -A N, --atsc_type N\n"
     "               specify ATSC type\n"
     "               1 = Terrestrial [default]\n"
@@ -4450,6 +4452,14 @@ int main(int argc, char **argv)
 		case 'f':	//frontend type -> hmmm..., actually it's scan type now! 20120109, -wk-
 			if (strcmp(optarg, "t") == 0)
 				scantype = SCAN_TERRESTRIAL;
+			if (strcmp(optarg, "t1") == 0) {
+				info("DVB-T only\n");
+				scantype = SCAN_TERRESTRIAL;
+			}
+			if (strcmp(optarg, "t2") == 0) {
+				info("DVB-T2 only\n");
+				scantype = SCAN_TERRESTRIAL;
+			}
 			if (strcmp(optarg, "c") == 0)
 				scantype = SCAN_CABLE;
 			if (strcmp(optarg, "a") == 0)

--- a/src/scan.c
+++ b/src/scan.c
@@ -4374,6 +4374,7 @@ int main(int argc, char **argv)
 	int frontend_fd = -1;
 	int fe_open_mode;
 	uint16_t scantype = SCAN_TERRESTRIAL;
+	uint16_t delsys = SYS_UNDEFINED;
 	int Radio_Services = 1;
 	int TV_Services = 1;
 	int Other_Services = 0;	// 20080106: don't search other services by default.
@@ -4453,12 +4454,12 @@ int main(int argc, char **argv)
 			if (strcmp(optarg, "t") == 0)
 				scantype = SCAN_TERRESTRIAL;
 			if (strcmp(optarg, "t1") == 0) {
-				info("DVB-T only\n");
 				scantype = SCAN_TERRESTRIAL;
+				delsys = SYS_DVBT;
 			}
 			if (strcmp(optarg, "t2") == 0) {
-				info("DVB-T2 only\n");
 				scantype = SCAN_TERRESTRIAL;
+				delsys = SYS_DVBT2;
 			}
 			if (strcmp(optarg, "c") == 0)
 				scantype = SCAN_CABLE;
@@ -4863,8 +4864,8 @@ int main(int argc, char **argv)
 			sleep(10);	// enshure that user reads warning.
 		}
 	}
-	info("scan type %s, channellist %d\n",
-	     scantype_to_text(scantype), this_channellist);
+	info("scan type %s, delivery system %s, channellist %d\n",
+	     scantype_to_text(scantype), delivery_system_name(delsys), this_channellist);
 	switch (output_format) {
 	case OUTPUT_VDR:
 		switch (flags.vdr_version) {

--- a/src/scan.c
+++ b/src/scan.c
@@ -3128,9 +3128,6 @@ static int initial_tune(int frontend_fd, int tuning_data)
 			delsys_min = delsysloop_min(0, this_channellist);
 			// enable T2 loop.
 			delsys_max = delsysloop_max(0, this_channellist);
-			// set plp_id range
-			plp_id_min = plp_id_loop_min (flags.list_id);
-			plp_id_max = plp_id_loop_max (flags.list_id);
 			break;
 		case SCAN_CABLE:
 			// if choosen srate is too high for channellist's bandwidth,
@@ -3171,6 +3168,11 @@ static int initial_tune(int frontend_fd, int tuning_data)
 				for (channel = 0; channel <= channel_max; channel++) {
 					for (offs = freq_offset_min; offs <= freq_offset_max; offs++) {
 						for (sr_parm = dvbc_symbolrate_min; sr_parm <= dvbc_symbolrate_max; sr_parm++) {
+							if (flags.scantype == SCAN_TERRESTRIAL) {
+								// set plp_id range for DVB-T : DVB-T2
+								plp_id_min = delsys_parm == 0 ? 0 : plp_id_loop_min (flags.list_id);
+								plp_id_max = delsys_parm == 0 ? 0 : plp_id_loop_max (flags.list_id);
+							}
 							for (plp_id_parm = plp_id_min; plp_id_parm <= plp_id_max; plp_id_parm++) {
 								test.type = flags.scantype;
 								switch (test.type) {

--- a/src/scan.c
+++ b/src/scan.c
@@ -3125,9 +3125,9 @@ static int initial_tune(int frontend_fd, int tuning_data)
 			modulation_min = modulation_max = 0;
 			dvbc_symbolrate_min = dvbc_symbolrate_max = 0;
 			// enable legacy delsys loop.
-			delsys_min = delsysloop_min(flags.list_id);
+			delsys_min = delsysloop_min(0, this_channellist);
 			// enable T2 loop.
-			delsys_max = delsysloop_max(flags.list_id);
+			delsys_max = delsysloop_max(0, this_channellist);
 			// set plp_id range
 			plp_id_min = plp_id_loop_min (flags.list_id);
 			plp_id_max = plp_id_loop_max (flags.list_id);

--- a/src/scan.h
+++ b/src/scan.h
@@ -57,6 +57,7 @@ struct w_scan_flags {
 	uint8_t print_pmt;
 	uint8_t emulate;
 	uint8_t delete_duplicate_transponders;
+	uint16_t delsys;
 };
 
 struct service *find_service(struct transponder *t, uint16_t service_id);


### PR DESCRIPTION
Hi Stefan,
because of the feedback concerning the use of the delivery systems I've made a larger rework. The situation seems not to be settled everywhere, so it is difficult to maintain it in the country list or by country. Therefore I added two command line parameters to set the delivery system to use.
  -ft1 scans for DVB-T only, overwrites the settings in the country list
  -ft2 scans for DVB-T2 only, overwrites the settings in the country list
  -ft scans for both, uses the settings in the country list
The plp range is given in the country list, now only set for AT.
The display of plp is changed to equal sr in DVB-C scan.
Comments are appreciated. I would be happy if you could accept my pull request.
