### PR TITLE
Fix build against musl libc

### DIFF
--- a/src/descriptors.h
+++ b/src/descriptors.h
@@ -23,6 +23,7 @@
 #define __DESCRIPTORS_H__
 
 #include "extended_frontend.h"
+#include "time.h"
 
 /******************************************************************************
  * descriptor ids as defined by standards.


### PR DESCRIPTION
Upstreaming of Alpine Linux's musl-build-time-h-fix.patch 