### PR TITLE
Add --input-charset option 

### DIFF
--- a/src/char-coding.h
+++ b/src/char-coding.h
@@ -33,6 +33,7 @@ int get_codepage_index(const char *codepage);
  * *inbuf && *outbuf will point to *different* memory afterwards.
  */
 void char_coding(char **inbuf, size_t * inbytesleft, char **outbuf,
-		 size_t * outbytesleft, unsigned user_charset_id);
+		 size_t * outbytesleft, const char *fallback_input_charset,
+		 unsigned int user_charset_id);
 
 #endif

--- a/src/descriptors.c
+++ b/src/descriptors.c
@@ -140,7 +140,8 @@ int repetition_rate(scantype_t scan_type, enum table_id table)
  *****************************************************************************/
 
 void parse_service_descriptor(const unsigned char *buf, struct service *s,
-			      unsigned user_charset_id)
+			      const char *fallback_input_charset,
+			      unsigned int user_charset_id)
 {
 	unsigned char len;
 	uint i, full_len, short_len, isUtf8;
@@ -263,7 +264,7 @@ void parse_service_descriptor(const unsigned char *buf, struct service *s,
 		inbuf = provider_name;
 		outbuf = s->provider_name;
 		char_coding(&inbuf, &inbytesleft, &outbuf, &outbytesleft,
-			    user_charset_id);
+			    fallback_input_charset, user_charset_id);
 	}
 
 	free(provider_name);
@@ -275,7 +276,7 @@ void parse_service_descriptor(const unsigned char *buf, struct service *s,
 		inbuf = provider_short_name;
 		outbuf = s->provider_short_name;
 		char_coding(&inbuf, &inbytesleft, &outbuf, &outbytesleft,
-			    user_charset_id);
+			    fallback_input_charset, user_charset_id);
 	}
 
 	free(provider_short_name);
@@ -382,7 +383,7 @@ void parse_service_descriptor(const unsigned char *buf, struct service *s,
 		inbuf = service_name;
 		outbuf = s->service_name;
 		char_coding(&inbuf, &inbytesleft, &outbuf, &outbytesleft,
-			    user_charset_id);
+			    fallback_input_charset, user_charset_id);
 	}
 
 	free(service_name);
@@ -394,7 +395,7 @@ void parse_service_descriptor(const unsigned char *buf, struct service *s,
 		inbuf = service_short_name;
 		outbuf = s->service_short_name;
 		char_coding(&inbuf, &inbytesleft, &outbuf, &outbytesleft,
-			    user_charset_id);
+			    fallback_input_charset, user_charset_id);
 	}
 
 	free(service_short_name);

--- a/src/descriptors.h
+++ b/src/descriptors.h
@@ -321,7 +321,8 @@ typedef struct {
 
 int repetition_rate(scantype_t scan_type, enum table_id table);
 void parse_service_descriptor(const unsigned char *buf, struct service *s,
-			      unsigned user_charset_id);
+			      const char *fallback_input_charset,
+			      unsigned int user_charset_id);
 void parse_ca_identifier_descriptor(const unsigned char *buf,
 				    struct service *s);
 void parse_ca_descriptor(const unsigned char *buf, struct service *s);

--- a/src/scan.c
+++ b/src/scan.c
@@ -108,6 +108,7 @@ struct w_scan_flags flags = {
 	0,			// emulate
 	0,			// delete duplicate transponders
 	SYS_UNDEFINED, // delivery system not defined
+	"ISO69372",		// fallback input charset
 };
 
 static unsigned int delsys_min = 0;	// initialization of delsys loop. 0 = delsys legacy.
@@ -1018,6 +1019,7 @@ static void parse_descriptors(enum table_id t, const unsigned char *buf,
 			if ((t == TABLE_SDT_ACT)
 			    || (t == TABLE_SDT_OTH))
 				parse_service_descriptor(buf, data,
+							 flags.fallback_input_charset,
 							 flags.codepage);
 			break;
 		case country_availability_descriptor:
@@ -3915,6 +3917,9 @@ static const char *usage = "\n"
 
 static const char *ext_opts = "%s expert help\n"
     ".................General.................\n"
+    "       --input-charset <charset>\n"
+    "               set fallback input charset in case the input charset couldn't\n"
+    "               be detected automatically. [default: ISO69372]\n"
     "       -C <charset>, --charset <charset>\n"
     "               convert to charset, i.e. 'UTF-8', 'ISO-8859-15'\n"
     "               use 'iconv --list' for full list of charsets.\n"
@@ -4068,6 +4073,7 @@ static struct option long_options[] = {
 	//---
 	{"extended-help", no_argument, NULL, 'H'},
 	{"charset", required_argument, NULL, 'C'},
+	{"input-charset", required_argument, NULL, 0},
 	{"initial", required_argument, NULL, 'I'},
 	{"verbose", no_argument, NULL, 'v'},
 	{"debug", no_argument, NULL, '!'},
@@ -4409,6 +4415,9 @@ int main(int argc, char **argv)
 			break;
 		case 'C':	// charset
 			codepage = strdup(optarg);
+			break;
+		case 0:		// input-charset (long-only)
+			flags.fallback_input_charset = optarg;
 			break;
 		case 'D':	//DiSEqC committed/uncommitted switch
 			sscanf(optarg, "%u%c", &i, &sw_type);

--- a/src/scan.h
+++ b/src/scan.h
@@ -58,6 +58,7 @@ struct w_scan_flags {
 	uint8_t emulate;
 	uint8_t delete_duplicate_transponders;
 	uint16_t delsys;
+	const char *fallback_input_charset;
 };
 
 struct service *find_service(struct transponder *t, uint16_t service_id);


### PR DESCRIPTION
Add `--input-charset <charset>` option to change the previously hardcoded fallback charset. and the previous hardcoded value '**ISO69372'** is still the default now.


@low-power and I found the charset detection failed.  charset **GB18030** can't be detect automatically.
So it would be nice to add an option to change the charset by user.