### PR TITLE
Mplayer output change

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 ChangeLog:
 --------------------
 [1.0.14]
+- include the PMT and teletext PIDs next to the video PID in the Mplayer
+  output (Robert Bartel <r.bartel@gmx.net>)
 
 [1.0.13] 2021-11-20
 - add satellite data from fastsatfinder.com

--- a/src/dump-mplayer.c
+++ b/src/dump-mplayer.c
@@ -37,7 +37,14 @@ void mplayer_dump_service_parameter_set(FILE * f,
 
 	fprintf(f, "%s:", s->service_name);
 	xine_dump_dvb_parameters(f, t, flags);
-	fprintf(f, ":%i:", s->video_pid);
+	fprintf(f, ":%i", s->pmt_pid);
+    if (s->video_pid) {
+        fprintf(f, "+%i", s->video_pid);
+    }
+    if (s->teletext_pid) {
+        fprintf(f, "+%i", s->teletext_pid);
+    }
+    fprintf(f, ":");
 
 	// build '+' separated list of mpeg audio and ac3 audio pids
 	if (s->audio_pid[0] || s->ac3_pid[0]) {


### PR DESCRIPTION
Include the PMT and teletext PIDs next to the video PID in the Mplayer output (Robert Bartel).