### PR TITLE
Add Panama

### DIFF
--- a/src/countries.c
+++ b/src/countries.c
@@ -256,9 +256,14 @@ choose_country(char const *country, int *atsc, int *dvb, uint16_t *scan_type, in
     }
     break;
     case PA: //      PANAMA, similar to US but uses channels 38 to 51
-        if (atsc_is_vsb(*atsc)) {
+        switch (*dvb) {
+        case SCAN_CABLE:
+            info("cable panama not yet defined.\n");
+            break;
+        default:
             *channellist = DVBT_PA;
             info("DVB-T PA\n");
+            break;
         }
         break;
     case CO: //      COLOMBIA, 6MHz offs 389MHz

--- a/src/countries.c
+++ b/src/countries.c
@@ -119,6 +119,7 @@ choose_country(char const *country, int *atsc, int *dvb, uint16_t *scan_type, in
     case SE: //      SWEDEN
     case SK: //      SLOVAKIA
     case TW: //      TAIWAN, DVB-T w. ATSC freq list (thanks for freqlist to mkrufky)
+    case PA: //      PANAMA, same as Taiwan
     case AU: //      AUSTRALIA, DVB-T w. 7MHz step
         switch (*dvb) {
         case SCAN_CABLE:
@@ -245,6 +246,7 @@ choose_country(char const *country, int *atsc, int *dvb, uint16_t *scan_type, in
     case US: //      UNITED STATES
     case CA: //      CANADA
     case TW: //      TAIWAN, DVB-T w. ATSC freq list
+    case PA: //      PANAMA, same as Taiwan
         if (atsc_is_vsb(*atsc)) {
             *channellist = ATSC_VSB;
             info("VSB US/CA, DVB-T TW\n");

--- a/src/countries.h
+++ b/src/countries.h
@@ -43,6 +43,7 @@ enum channellist_t {
     ISDBT_6MHZ = 11,
     DAB_DE = 12,
     DVBT2_CO = 13,
+    DVBT_PA = 14,
     USERLIST = 999
 };
 


### PR DESCRIPTION
For issue #63. Apparently Taiwan and Panama are the only countries in the world that use DVB-T on a 6 MHz channel bandwidth. https://en.wikipedia.org/wiki/Television_channel_frequencies#UHF 