### PR TITLE
Add frequency tables for China

### DIFF
--- a/src/countries.h
+++ b/src/countries.h
@@ -44,6 +44,8 @@ enum channellist_t {
     DAB_DE = 12,
     DVBT2_CO = 13,
     DVBT_PA = 14,
+    DVBC_CN = 15,
+    DTMB_CN = 16,
     USERLIST = 999
 };
 


### PR DESCRIPTION
I have added cable and terrestrial frequency tables for China. 
China uses standard DVB-C for cable with different VHF frequencies, terrestrial uses DTMB but most tuners report themselves as DVB-T, so it might also work.
(Source: https://zh.wikipedia.org/wiki/中华人民共和国电视频道频率划分列表)
