### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/descriptors.c
+++ b/src/descriptors.c
@@ -801,7 +801,6 @@ parse_cable_delivery_system_descriptor(unsigned char const *buf, struct transpon
 void
 parse_C2_delivery_system_descriptor(unsigned char const *buf, struct transponder *t, fe_spectral_inversion_t inversion)
 {
-    __u8 descriptor_length;
     //__u8 descriptor_tag_extension;
     unsigned char *bp;
 
@@ -814,20 +813,15 @@ parse_C2_delivery_system_descriptor(unsigned char const *buf, struct transponder
     t->delsys = SYS_DVBC2;
     t->inversion = inversion;
     // descriptor_tag               8 uimsbf
-    descriptor_length = buf[1]; // descriptor_length            8 uimsbf
     // descriptor_tag_extension = buf[2];                                                                 //
     // descriptor_tag_extension     8 uimsbf
     bp = (unsigned char *)&buf[3];
-    descriptor_length--;
     t->plp_id = *bp; // plp_id                       8 uimsbf; uniquely identifies a data PLP within the C2 System
     bp++;
-    descriptor_length--;
     t->data_slice_id = *bp; // data_slice_id                8 uimsbf; uniquely identifies a data slice within the C2 system
     bp++;
-    descriptor_length--;
     t->frequency = get_u32(bp); // C2_tuning_frequency          32 bslbf; see C2_tuning_frequency_type
     bp += 4;
-    descriptor_length -= 4;
     switch ((*bp & 0xC0) >> 6) { // C2_tuning_frequency_type     2 uimsbf
     case 0:
         t->C2_tuning_frequency_type = DATA_SLICE_TUNING_FREQUENCY;
@@ -866,7 +860,6 @@ parse_C2_delivery_system_descriptor(unsigned char const *buf, struct transponder
         t->guard = GUARD_INTERVAL_1_128; // defaulting to here to 1/128, as nothing better found so far.
     }
     bp++;
-    descriptor_length--;
 }
 
 /*
@@ -1187,7 +1180,6 @@ parse_T2_delivery_system_descriptor(unsigned char const *buf, struct transponder
 {
     unsigned char *bp;
     __u8 descriptor_length;
-    __u8 frequency_loop_length = 0;
     __u8 subcell_info_loop_length = 0;
     __u32 center_frequency = 0;
     struct cell *p;
@@ -1326,7 +1318,6 @@ parse_T2_delivery_system_descriptor(unsigned char const *buf, struct transponder
                 center_frequency = 10 * get_u32(bp);
                 bp += 4;
                 descriptor_length -= 4; //         centre_frequency 32 uimsbf
-                frequency_loop_length -= 4; //
                 if ((center_frequency < 50000000) || (center_frequency > 1000000000))
                     center_frequency = 0;
                 cell->center_frequencies[cell->num_center_frequencies++] = center_frequency; //
@@ -1387,8 +1378,7 @@ parse_T2_delivery_system_descriptor(unsigned char const *buf, struct transponder
             t->tfs_flag);
 
         verbose("          %u cells:\n", (t->cells)->count);
-        int i = 0;
-        for (p = (t->cells)->first; p; p = p->next, ++i) {
+        for (p = (t->cells)->first; p; p = p->next) {
             int n;
             for (n = 0; n < p->num_center_frequencies; n++)
                 verbose("             cell %u: center_frequency %7.3f\n", p->cell_id, p->center_frequencies[n] / 1000000.0);

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -362,7 +362,7 @@ has_lock(fe_delivery_system_t em_delsys, struct transponder *t)
             EM_INFO("wrong pilot: %d != %d\n", t->pilot, em_device.pilot);
             return 0;
         }
-        /* fall trough. */
+        /* falls through */
     case SYS_DVBS:
         if (em_device.highband)
             tp_if = abs(t->frequency - em_device.lnb_high);
@@ -1359,6 +1359,7 @@ parse_logfile(char const *log)
                     break;
                 case SYS_ATSC:
                     sidata->t.type = SCAN_TERRCABLE_ATSC;
+                    /* falls through */
                 default:
                     fatal("unsupported del sys.\n");
                 }

--- a/src/parse-dvbscan.c
+++ b/src/parse-dvbscan.c
@@ -252,8 +252,8 @@ dvbscan_parse_tuningdata(char const *tuningdata, struct w_scan_flags *flags)
             tn->modulation = VSB_8;
             break;
         default:
-            free(buf);
             error("could not parse '%s' - undefined fe_type\n", buf);
+            free(buf);
             return 0; // err
         }
 

--- a/src/parse-dvbscan.c
+++ b/src/parse-dvbscan.c
@@ -424,7 +424,8 @@ vdr_code_from_token(char const *token)
             dot++;
             break;
         case 'E':
-            neg++; // no break, fall through
+            neg++;
+            /* falls through */
         case 'W':
             if (!dot)
                 pos *= 10;
@@ -557,6 +558,7 @@ dvbscan_parse_rotor_positions(char const *positiondata)
                     error("could not parse %s\n", positiondata);
                     goto err;
                 }
+                /* falls through */
             case sat_id:
                 if (item.id)
                     free(item.id);
@@ -583,6 +585,7 @@ dvbscan_parse_rotor_positions(char const *positiondata)
                     error("could not parse %s\n", positiondata);
                     goto err;
                 }
+                /* falls through */
             case end_of_line_rotor:
             case READ_STOP:
             default:

--- a/src/scan.c
+++ b/src/scan.c
@@ -274,7 +274,7 @@ is_auto_params(struct transponder *t)
     case SYS_DVBS2:
         if (t->rolloff == ROLLOFF_AUTO)
             return true;
-        /* fall trough. */
+        /* falls through */
     case SYS_DSS:
     case SYS_DVBS:
         if (t->coderate == FEC_AUTO)
@@ -2394,6 +2394,7 @@ set_frontend(int frontend_fd, struct transponder *t)
             info("\t skipped: (srate %u unsupported by driver)\n", t->symbolrate);
             return -2;
         }
+        /* falls through */
     case SCAN_TERRESTRIAL:
         if (t->delsys == SYS_DVBT2) {
             if (!(fe_info.caps & FE_CAN_2G_MODULATION)) {
@@ -2401,7 +2402,7 @@ set_frontend(int frontend_fd, struct transponder *t)
                 return -2;
             }
         }
-        // no break needed here.
+        /* falls through */
     case SCAN_TERRCABLE_ATSC:
         if ((t->frequency < fe_info.frequency_min) || (t->frequency > fe_info.frequency_max)) {
             info("\t skipped: (freq %u unsupported by driver)\n", t->frequency);


### PR DESCRIPTION
Further cleanups
- fix compiler warning -Wunused-but-set-variable=
- fix compiler warning -Wuse-after-free
- fix compiler warning -Wimplicit-fallthrough=

remaining warnings are:
- warning: 'strncpy' specified bound … equals destination size [-Wstringop-truncation]
- taking the absolute value of unsigned type '…' {aka '…'} has no effect [-Wabsolute-value]
- warning: '%.2d' directive writing between 2 and 3 bytes into a region of size between 2 and 9 [-Wformat-overflow=]
- warning: 'strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
- warning: using integer absolute value function 'abs' when argument is of floating-point type 'float' [-Wabsolute-value]